### PR TITLE
fix directly calling create() from viewModelFactory

### DIFF
--- a/Cognizant_x_Avans_Hogeschool_Python_Colab_Tutorial_0922.ipynb
+++ b/Cognizant_x_Avans_Hogeschool_Python_Colab_Tutorial_0922.ipynb
@@ -1,0 +1,2323 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "collapsed_sections": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.6"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/neorejalist/Forage/blob/main/Cognizant_x_Avans_Hogeschool_Python_Colab_Tutorial_0922.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dzNng6vCL9eP"
+      },
+      "source": [
+        "#Python Tutorial With Google Colab\n",
+        "Cognizant x Avans Hogeschool"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vKOaKrP_pwE3"
+      },
+      "source": [
+        "👋👨‍💻 Welkom bij deze Python Tutorial!\n",
+        "\n",
+        "Raak alvast bekend met Python in deze omgeving van Google genaamd Colaboratory. Wij Data Scientists werken heel veel met dit soort 'notebooks'. Python is een superkrachtige programmeertaal maar ook heel straight-forward. \n",
+        "\n",
+        "Hoewel je de hands-on workshop in principe zonder Python-ervaring kunt doen, is het handig alvast te wennen aan deze programmeertaal. Doe jezelf een plezier en kijk of je alles uit deze tutorial snapt om volgende week een vliegende start te kunnen maken. Volgende week zullen jullie namelijk zelf een machine learning model programmeren.\n",
+        "\n",
+        "Succes met deze tutorial en tot volgende week!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qVrTo-LhL9eS"
+      },
+      "source": [
+        "##Introduction"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9t1gKp9PL9eV"
+      },
+      "source": [
+        "Python is a great general-purpose programming language on its own, but with the help of a few popular libraries (numpy, scipy, matplotlib) it becomes a powerful environment for scientific computing.\n",
+        "\n",
+        "We expect that many of you will have some experience with Python and numpy; for the rest of you, this section will serve as a quick crash course both on the Python programming language and on the use of Python for scientific computing."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U1PvreR9L9eW"
+      },
+      "source": [
+        "In this tutorial, we will cover:\n",
+        "\n",
+        "* Basic Python: Basic data types (Containers, Lists, Dictionaries, Sets, Tuples), Functions, Classes\n",
+        "* Numpy: Arrays, Array indexing, Datatypes, Array math, Broadcasting\n",
+        "* Matplotlib: Plotting, Subplots, Images\n",
+        "* Pandas: loading, wrangling, and more with data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nxvEkGXPM3Xh"
+      },
+      "source": [
+        "## A Brief Note on Python Versions\n",
+        "\n",
+        "As of Janurary 1, 2020, Python has [officially dropped support](https://www.python.org/doc/sunset-python-2/) for `python2`. We'll be using Python 3.7 for this iteration of the course. You can check your Python version at the command line by running `python --version`. In Colab, we can enforce the Python version by clicking `Runtime -> Change Runtime Type` and selecting `python3`. Note that as of April 2020, Colab uses Python 3.6.9 which should run everything without any errors."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1L4Am0QATgOc"
+      },
+      "source": [
+        "!python --version"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NwS_hu4xL9eo"
+      },
+      "source": [
+        "###Basic data types"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DL5sMSZ9L9eq"
+      },
+      "source": [
+        "####Numbers"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MGS0XEWoL9er"
+      },
+      "source": [
+        "Integers and floats work as you would expect from other languages:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "KheDr_zDL9es"
+      },
+      "source": [
+        "x = 3\n",
+        "print(x, type(x))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "sk_8DFcuL9ey"
+      },
+      "source": [
+        "print(x + 1)   # Addition\n",
+        "print(x - 1)   # Subtraction\n",
+        "print(x * 2)   # Multiplication\n",
+        "print(x ** 2)  # Exponentiation"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "U4Jl8K0tL9e4"
+      },
+      "source": [
+        "x += 1\n",
+        "print(x)\n",
+        "x *= 2\n",
+        "print(x)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "w-nZ0Sg_L9e9"
+      },
+      "source": [
+        "y = 2.5\n",
+        "print(type(y))\n",
+        "print(y, y + 1, y * 2, y ** 2)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "r2A9ApyaL9fB"
+      },
+      "source": [
+        "Note that unlike many languages, Python does not have unary increment (x++) or decrement (x--) operators.\n",
+        "\n",
+        "Python also has built-in types for long integers and complex numbers; you can find all of the details in the [documentation](https://docs.python.org/3.7/library/stdtypes.html#numeric-types-int-float-long-complex)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EqRS7qhBL9fC"
+      },
+      "source": [
+        "####Booleans"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Nv_LIVOJL9fD"
+      },
+      "source": [
+        "Python implements all of the usual operators for Boolean logic, but uses English words rather than symbols (`&&`, `||`, etc.):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RvoImwgGL9fE"
+      },
+      "source": [
+        "t, f = True, False\n",
+        "print(type(t))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YQgmQfOgL9fI"
+      },
+      "source": [
+        "Now we let's look at the operations:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6zYm7WzCL9fK"
+      },
+      "source": [
+        "print(t and f) # Logical AND;\n",
+        "print(t or f)  # Logical OR;\n",
+        "print(not t)   # Logical NOT;\n",
+        "print(t != f)  # Logical XOR;"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UQnQWFEyL9fP"
+      },
+      "source": [
+        "####Strings"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "AijEDtPFL9fP"
+      },
+      "source": [
+        "hello = 'hello'   # String literals can use single quotes\n",
+        "world = \"world\"   # or double quotes; it does not matter\n",
+        "print(hello, len(hello))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "saDeaA7hL9fT"
+      },
+      "source": [
+        "hw = hello + ' ' + world  # String concatenation\n",
+        "print(hw)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Nji1_UjYL9fY"
+      },
+      "source": [
+        "hw12 = '{} {} {}'.format(hello, world, 12)  # string formatting\n",
+        "print(hw12)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "06cayXLtL9fi"
+      },
+      "source": [
+        "You can find a list of all string methods in the [documentation](https://docs.python.org/3.7/library/stdtypes.html#string-methods)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "p-6hClFjL9fk"
+      },
+      "source": [
+        "###Containers"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FD9H18eQL9fk"
+      },
+      "source": [
+        "Python includes several built-in container types: lists, dictionaries, sets, and tuples."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UsIWOe0LL9fn"
+      },
+      "source": [
+        "####Lists"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wzxX7rgWL9fn"
+      },
+      "source": [
+        "A list is the Python equivalent of an array, but is resizeable and can contain elements of different types:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "hk3A8pPcL9fp"
+      },
+      "source": [
+        "xs = [3, 1, 2]   # Create a list\n",
+        "print(xs, xs[2])\n",
+        "print(xs[-1])     # Negative indices count from the end of the list; prints \"2\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "YCjCy_0_L9ft"
+      },
+      "source": [
+        "xs[2] = 'foo'    # Lists can contain elements of different types\n",
+        "print(xs)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vJ0x5cF-L9fx"
+      },
+      "source": [
+        "xs.append('bar') # Add a new element to the end of the list\n",
+        "print(xs)  "
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ilyoyO34L9f4"
+      },
+      "source": [
+        "As usual, you can find all the gory details about lists in the [documentation](https://docs.python.org/3.7/tutorial/datastructures.html#more-on-lists)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ovahhxd_L9f5"
+      },
+      "source": [
+        "####Slicing"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YeSYKhv9L9f6"
+      },
+      "source": [
+        "In addition to accessing list elements one at a time, Python provides concise syntax to access sublists; this is known as slicing:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ninq666bL9f6"
+      },
+      "source": [
+        "nums = list(range(5))    # range is a built-in function that creates a list of integers\n",
+        "print(nums)         # Prints \"[0, 1, 2, 3, 4]\"\n",
+        "print(nums[2:4])    # Get a slice from index 2 to 4 (exclusive); prints \"[2, 3]\"\n",
+        "print(nums[2:])     # Get a slice from index 2 to the end; prints \"[2, 3, 4]\"\n",
+        "print(nums[:2])     # Get a slice from the start to index 2 (exclusive); prints \"[0, 1]\"\n",
+        "print(nums[:])      # Get a slice of the whole list; prints [\"0, 1, 2, 3, 4]\"\n",
+        "print(nums[:-1])    # Slice indices can be negative; prints [\"0, 1, 2, 3]\"\n",
+        "nums[2:4] = [8, 9] # Assign a new sublist to a slice\n",
+        "print(nums)         # Prints \"[0, 1, 8, 9, 4]\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UONpMhF4L9f_"
+      },
+      "source": [
+        "####Loops"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_DYz1j6QL9f_"
+      },
+      "source": [
+        "You can loop over the elements of a list like this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4cCOysfWL9gA"
+      },
+      "source": [
+        "animals = ['cat', 'dog', 'monkey']\n",
+        "for animal in animals:\n",
+        "    print(animal)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KxIaQs7pL9gE"
+      },
+      "source": [
+        "If you want access to the index of each element within the body of a loop, use the built-in `enumerate` function:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "JjGnDluWL9gF"
+      },
+      "source": [
+        "animals = ['cat', 'dog', 'monkey']\n",
+        "for idx, animal in enumerate(animals):\n",
+        "    print('#{}: {}'.format(idx + 1, animal))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "arrLCcMyL9gK"
+      },
+      "source": [
+        "####List comprehensions:"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5Qn2jU_pL9gL"
+      },
+      "source": [
+        "When programming, frequently we want to transform one type of data into another. As a simple example, consider the following code that computes square numbers:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "IVNEwoMXL9gL"
+      },
+      "source": [
+        "nums = [0, 1, 2, 3, 4]\n",
+        "squares = []\n",
+        "for x in nums:\n",
+        "    squares.append(x ** 2)\n",
+        "print(squares)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7DmKVUFaL9gQ"
+      },
+      "source": [
+        "You can make this code simpler using a list comprehension:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kZxsUfV6L9gR"
+      },
+      "source": [
+        "nums = [0, 1, 2, 3, 4]\n",
+        "squares = [x ** 2 for x in nums]\n",
+        "print(squares)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-D8ARK7tL9gV"
+      },
+      "source": [
+        "List comprehensions can also contain conditions:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yUtgOyyYL9gV"
+      },
+      "source": [
+        "nums = [0, 1, 2, 3, 4]\n",
+        "even_squares = [x ** 2 for x in nums if x % 2 == 0]\n",
+        "print(even_squares)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H8xsUEFpL9gZ"
+      },
+      "source": [
+        "####Dictionaries"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kkjAGMAJL9ga"
+      },
+      "source": [
+        "A dictionary stores (key, value) pairs, similar to a `Map` in Java or an object in Javascript. You can use it like this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XBYI1MrYL9gb"
+      },
+      "source": [
+        "d = {'cat': 'cute', 'dog': 'furry'}  # Create a new dictionary with some data\n",
+        "print(d['cat'])       # Get an entry from a dictionary; prints \"cute\"\n",
+        "print('cat' in d)     # Check if a dictionary has a given key; prints \"True\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pS7e-G-HL9gf"
+      },
+      "source": [
+        "d['fish'] = 'wet'    # Set an entry in a dictionary\n",
+        "print(d['fish'])      # Prints \"wet\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "tFY065ItL9gi"
+      },
+      "source": [
+        "print(d['monkey'])  # KeyError: 'monkey' not a key of d"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wqm4dRZNL9gr"
+      },
+      "source": [
+        "You can find all you need to know about dictionaries in the [documentation](https://docs.python.org/2/library/stdtypes.html#dict)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IxwEqHlGL9gr"
+      },
+      "source": [
+        "It is easy to iterate over the keys in a dictionary:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "rYfz7ZKNL9gs"
+      },
+      "source": [
+        "d = {'person': 2, 'cat': 4, 'spider': 8}\n",
+        "for animal, legs in d.items():\n",
+        "    print('A {} has {} legs'.format(animal, legs))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "17sxiOpzL9gz"
+      },
+      "source": [
+        "Dictionary comprehensions: These are similar to list comprehensions, but allow you to easily construct dictionaries. For example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8PB07imLL9gz"
+      },
+      "source": [
+        "nums = [0, 1, 2, 3, 4]\n",
+        "even_num_to_square = {x: x ** 2 for x in nums if x % 2 == 0}\n",
+        "print(even_num_to_square)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "V9MHfUdvL9g2"
+      },
+      "source": [
+        "####Sets"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Rpm4UtNpL9g2"
+      },
+      "source": [
+        "A set is an unordered collection of distinct elements. As a simple example, consider the following:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MmyaniLsL9g2"
+      },
+      "source": [
+        "animals = {'cat', 'dog'}\n",
+        "print('cat' in animals)   # Check if an element is in a set; prints \"True\"\n",
+        "print('fish' in animals)  # prints \"False\"\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ElJEyK86L9g6"
+      },
+      "source": [
+        "animals.add('fish')      # Add an element to a set\n",
+        "print('fish' in animals)\n",
+        "print(len(animals))       # Number of elements in a set;"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "5uGmrxdPL9g9"
+      },
+      "source": [
+        "animals.add('cat')       # Adding an element that is already in the set does nothing\n",
+        "print(len(animals))       \n",
+        "animals.remove('cat')    # Remove an element from a set\n",
+        "print(len(animals))       "
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zk2DbvLKL9g_"
+      },
+      "source": [
+        "_Loops_: Iterating over a set has the same syntax as iterating over a list; however since sets are unordered, you cannot make assumptions about the order in which you visit the elements of the set:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "K47KYNGyL9hA"
+      },
+      "source": [
+        "animals = {'cat', 'dog', 'fish'}\n",
+        "for idx, animal in enumerate(animals):\n",
+        "    print('#{}: {}'.format(idx + 1, animal))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "puq4S8buL9hC"
+      },
+      "source": [
+        "Set comprehensions: Like lists and dictionaries, we can easily construct sets using set comprehensions:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "iw7k90k3L9hC"
+      },
+      "source": [
+        "from math import sqrt\n",
+        "print({int(sqrt(x)) for x in range(30)})"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AXA4jrEOL9hM"
+      },
+      "source": [
+        "###Functions"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WaRms-QfL9hN"
+      },
+      "source": [
+        "Python functions are defined using the `def` keyword. For example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kiMDUr58L9hN"
+      },
+      "source": [
+        "def sign(x):\n",
+        "    if x > 0:\n",
+        "        return 'positive'\n",
+        "    elif x < 0:\n",
+        "        return 'negative'\n",
+        "    else:\n",
+        "        return 'zero'\n",
+        "\n",
+        "for x in [-1, 0, 1]:\n",
+        "    print(sign(x))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U-QJFt8TL9hR"
+      },
+      "source": [
+        "We will often define functions to take optional keyword arguments, like this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "PfsZ3DazL9hR"
+      },
+      "source": [
+        "def hello(name, loud=False):\n",
+        "    if loud:\n",
+        "        print('HELLO, {}'.format(name.upper()))\n",
+        "    else:\n",
+        "        print('Hello, {}!'.format(name))\n",
+        "\n",
+        "hello('Bob')\n",
+        "hello('Fred', loud=True)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ObA9PRtQL9hT"
+      },
+      "source": [
+        "###Classes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hAzL_lTkL9hU"
+      },
+      "source": [
+        "The syntax for defining classes in Python is straightforward:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RWdbaGigL9hU"
+      },
+      "source": [
+        "class Greeter:\n",
+        "\n",
+        "    # Constructor\n",
+        "    def __init__(self, name):\n",
+        "        self.name = name  # Create an instance variable\n",
+        "\n",
+        "    # Instance method\n",
+        "    def greet(self, loud=False):\n",
+        "        if loud:\n",
+        "          print('HELLO, {}'.format(self.name.upper()))\n",
+        "        else:\n",
+        "          print('Hello, {}!'.format(self.name))\n",
+        "\n",
+        "g = Greeter('Fred')  # Construct an instance of the Greeter class\n",
+        "g.greet()            # Call an instance method; prints \"Hello, Fred\"\n",
+        "g.greet(loud=True)   # Call an instance method; prints \"HELLO, FRED!\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3cfrOV4dL9hW"
+      },
+      "source": [
+        "##Numpy"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fY12nHhyL9hX"
+      },
+      "source": [
+        "Numpy is the core library for scientific computing in Python. It provides a high-performance multidimensional array object, and tools for working with these arrays. If you are already familiar with MATLAB, you might find this [tutorial](http://wiki.scipy.org/NumPy_for_Matlab_Users) useful to get started with Numpy."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lZMyAdqhL9hY"
+      },
+      "source": [
+        "To use Numpy, we first need to import the `numpy` package:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "58QdX8BLL9hZ"
+      },
+      "source": [
+        "import numpy as np"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DDx6v1EdL9hb"
+      },
+      "source": [
+        "###Arrays"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f-Zv3f7LL9hc"
+      },
+      "source": [
+        "A numpy array is a grid of values, all of the same type, and is indexed by a tuple of nonnegative integers. The number of dimensions is the rank of the array; the shape of an array is a tuple of integers giving the size of the array along each dimension."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_eMTRnZRL9hc"
+      },
+      "source": [
+        "We can initialize numpy arrays from nested Python lists, and access elements using square brackets:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-l3JrGxCL9hc"
+      },
+      "source": [
+        "a = np.array([1, 2, 3])  # Create a rank 1 array\n",
+        "print(type(a), a.shape, a[0], a[1], a[2])\n",
+        "a[0] = 5                 # Change an element of the array\n",
+        "print(a)                  "
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ma6mk-kdL9hh"
+      },
+      "source": [
+        "b = np.array([[1,2,3],[4,5,6]])   # Create a rank 2 array\n",
+        "print(b)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ymfSHAwtL9hj"
+      },
+      "source": [
+        "print(b.shape)\n",
+        "print(b[0, 0], b[0, 1], b[1, 0])"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "F2qwdyvuL9hn"
+      },
+      "source": [
+        "Numpy also provides many functions to create arrays:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "mVTN_EBqL9hn"
+      },
+      "source": [
+        "a = np.zeros((2,2))  # Create an array of all zeros\n",
+        "print(a)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "skiKlNmlL9h5"
+      },
+      "source": [
+        "b = np.ones((1,2))   # Create an array of all ones\n",
+        "print(b)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HtFsr03bL9h7"
+      },
+      "source": [
+        "c = np.full((2,2), 7) # Create a constant array\n",
+        "print(c)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "-QcALHvkL9h9"
+      },
+      "source": [
+        "d = np.eye(2)        # Create a 2x2 identity matrix\n",
+        "print(d)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RCpaYg9qL9iA"
+      },
+      "source": [
+        "e = np.random.random((2,2)) # Create an array filled with random values\n",
+        "print(e)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jI5qcSDfL9iC"
+      },
+      "source": [
+        "###Array indexing"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "M-E4MUeVL9iC"
+      },
+      "source": [
+        "Numpy offers several ways to index into arrays."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QYv4JyIEL9iD"
+      },
+      "source": [
+        "Slicing: Similar to Python lists, numpy arrays can be sliced. Since arrays may be multidimensional, you must specify a slice for each dimension of the array:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "wLWA0udwL9iD"
+      },
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "# Create the following rank 2 array with shape (3, 4)\n",
+        "# [[ 1  2  3  4]\n",
+        "#  [ 5  6  7  8]\n",
+        "#  [ 9 10 11 12]]\n",
+        "a = np.array([[1,2,3,4], [5,6,7,8], [9,10,11,12]])\n",
+        "\n",
+        "# Use slicing to pull out the subarray consisting of the first 2 rows\n",
+        "# and columns 1 and 2; b is the following array of shape (2, 2):\n",
+        "# [[2 3]\n",
+        "#  [6 7]]\n",
+        "b = a[:2, 1:3]\n",
+        "print(b)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KahhtZKYL9iF"
+      },
+      "source": [
+        "A slice of an array is a view into the same data, so modifying it will modify the original array."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1kmtaFHuL9iG"
+      },
+      "source": [
+        "print(a[0, 1])\n",
+        "b[0, 0] = 77    # b[0, 0] is the same piece of data as a[0, 1]\n",
+        "print(a[0, 1]) "
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_Zcf3zi-L9iI"
+      },
+      "source": [
+        "You can also mix integer indexing with slice indexing. However, doing so will yield an array of lower rank than the original array. Note that this is quite different from the way that MATLAB handles array slicing:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "G6lfbPuxL9iJ"
+      },
+      "source": [
+        "# Create the following rank 2 array with shape (3, 4)\n",
+        "a = np.array([[1,2,3,4], [5,6,7,8], [9,10,11,12]])\n",
+        "print(a)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NCye3NXhL9iL"
+      },
+      "source": [
+        "Two ways of accessing the data in the middle row of the array.\n",
+        "Mixing integer indexing with slices yields an array of lower rank,\n",
+        "while using only slices yields an array of the same rank as the\n",
+        "original array:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "EOiEMsmNL9iL"
+      },
+      "source": [
+        "row_r1 = a[1, :]    # Rank 1 view of the second row of a  \n",
+        "row_r2 = a[1:2, :]  # Rank 2 view of the second row of a\n",
+        "row_r3 = a[[1], :]  # Rank 2 view of the second row of a\n",
+        "print(row_r1, row_r1.shape)\n",
+        "print(row_r2, row_r2.shape)\n",
+        "print(row_r3, row_r3.shape)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "JXu73pfDL9iN"
+      },
+      "source": [
+        "# We can make the same distinction when accessing columns of an array:\n",
+        "col_r1 = a[:, 1]\n",
+        "col_r2 = a[:, 1:2]\n",
+        "print(col_r1, col_r1.shape)\n",
+        "print()\n",
+        "print(col_r2, col_r2.shape)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VP3916bOL9iP"
+      },
+      "source": [
+        "Integer array indexing: When you index into numpy arrays using slicing, the resulting array view will always be a subarray of the original array. In contrast, integer array indexing allows you to construct arbitrary arrays using the data from another array. Here is an example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TBnWonIDL9iP"
+      },
+      "source": [
+        "a = np.array([[1,2], [3, 4], [5, 6]])\n",
+        "\n",
+        "# An example of integer array indexing.\n",
+        "# The returned array will have shape (3,) and \n",
+        "print(a[[0, 1, 2], [0, 1, 0]])\n",
+        "\n",
+        "# The above example of integer array indexing is equivalent to this:\n",
+        "print(np.array([a[0, 0], a[1, 1], a[2, 0]]))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "n7vuati-L9iR"
+      },
+      "source": [
+        "# When using integer array indexing, you can reuse the same\n",
+        "# element from the source array:\n",
+        "print(a[[0, 0], [1, 1]])\n",
+        "\n",
+        "# Equivalent to the previous integer array indexing example\n",
+        "print(np.array([a[0, 1], a[0, 1]]))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kaipSLafL9iU"
+      },
+      "source": [
+        "One useful trick with integer array indexing is selecting or mutating one element from each row of a matrix:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ehqsV7TXL9iU"
+      },
+      "source": [
+        "# Create a new array from which we will select elements\n",
+        "a = np.array([[1,2,3], [4,5,6], [7,8,9], [10, 11, 12]])\n",
+        "print(a)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pAPOoqy5L9iV"
+      },
+      "source": [
+        "# Create an array of indices\n",
+        "b = np.array([0, 2, 0, 1])\n",
+        "\n",
+        "# Select one element from each row of a using the indices in b\n",
+        "print(a[np.arange(4), b])  # Prints \"[ 1  6  7 11]\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6v1PdI1DL9ib"
+      },
+      "source": [
+        "# Mutate one element from each row of a using the indices in b\n",
+        "a[np.arange(4), b] += 10\n",
+        "print(a)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kaE8dBGgL9id"
+      },
+      "source": [
+        "Boolean array indexing: Boolean array indexing lets you pick out arbitrary elements of an array. Frequently this type of indexing is used to select the elements of an array that satisfy some condition. Here is an example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "32PusjtKL9id"
+      },
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "a = np.array([[1,2], [3, 4], [5, 6]])\n",
+        "\n",
+        "bool_idx = (a > 2)  # Find the elements of a that are bigger than 2;\n",
+        "                    # this returns a numpy array of Booleans of the same\n",
+        "                    # shape as a, where each slot of bool_idx tells\n",
+        "                    # whether that element of a is > 2.\n",
+        "\n",
+        "print(bool_idx)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "cb2IRMXaL9if"
+      },
+      "source": [
+        "# We use boolean array indexing to construct a rank 1 array\n",
+        "# consisting of the elements of a corresponding to the True values\n",
+        "# of bool_idx\n",
+        "print(a[bool_idx])\n",
+        "\n",
+        "# We can do all of the above in a single concise statement:\n",
+        "print(a[a > 2])"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CdofMonAL9ih"
+      },
+      "source": [
+        "For brevity we have left out a lot of details about numpy array indexing; if you want to know more you should read the documentation."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jTctwqdQL9ih"
+      },
+      "source": [
+        "###Datatypes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "kSZQ1WkIL9ih"
+      },
+      "source": [
+        "Every numpy array is a grid of elements of the same type. Numpy provides a large set of numeric datatypes that you can use to construct arrays. Numpy tries to guess a datatype when you create an array, but functions that construct arrays usually also include an optional argument to explicitly specify the datatype. Here is an example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4za4O0m5L9ih"
+      },
+      "source": [
+        "x = np.array([1, 2])  # Let numpy choose the datatype\n",
+        "y = np.array([1.0, 2.0])  # Let numpy choose the datatype\n",
+        "z = np.array([1, 2], dtype=np.int64)  # Force a particular datatype\n",
+        "\n",
+        "print(x.dtype, y.dtype, z.dtype)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RLVIsZQpL9ik"
+      },
+      "source": [
+        "You can read all about numpy datatypes in the [documentation](http://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TuB-fdhIL9ik"
+      },
+      "source": [
+        "###Array math"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "18e8V8elL9ik"
+      },
+      "source": [
+        "Basic mathematical functions operate elementwise on arrays, and are available both as operator overloads and as functions in the numpy module:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gHKvBrSKL9il"
+      },
+      "source": [
+        "x = np.array([[1,2],[3,4]], dtype=np.float64)\n",
+        "y = np.array([[5,6],[7,8]], dtype=np.float64)\n",
+        "\n",
+        "# Elementwise sum; both produce the array\n",
+        "print(x + y)\n",
+        "print(np.add(x, y))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1fZtIAMxL9in"
+      },
+      "source": [
+        "# Elementwise difference; both produce the array\n",
+        "print(x - y)\n",
+        "print(np.subtract(x, y))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "nil4AScML9io"
+      },
+      "source": [
+        "# Elementwise product; both produce the array\n",
+        "print(x * y)\n",
+        "print(np.multiply(x, y))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0JoA4lH6L9ip"
+      },
+      "source": [
+        "# Elementwise division; both produce the array\n",
+        "# [[ 0.2         0.33333333]\n",
+        "#  [ 0.42857143  0.5       ]]\n",
+        "print(x / y)\n",
+        "print(np.divide(x, y))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "g0iZuA6bL9ir"
+      },
+      "source": [
+        "# Elementwise square root; produces the array\n",
+        "# [[ 1.          1.41421356]\n",
+        "#  [ 1.73205081  2.        ]]\n",
+        "print(np.sqrt(x))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "a5d_uujuL9it"
+      },
+      "source": [
+        "Note that unlike MATLAB, `*` is elementwise multiplication, not matrix multiplication. We instead use the dot function to compute inner products of vectors, to multiply a vector by a matrix, and to multiply matrices. dot is available both as a function in the numpy module and as an instance method of array objects:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "I3FnmoSeL9iu"
+      },
+      "source": [
+        "x = np.array([[1,2],[3,4]])\n",
+        "y = np.array([[5,6],[7,8]])\n",
+        "\n",
+        "v = np.array([9,10])\n",
+        "w = np.array([11, 12])\n",
+        "\n",
+        "# Inner product of vectors; both produce 219\n",
+        "print(v.dot(w))\n",
+        "print(np.dot(v, w))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vmxPbrHASVeA"
+      },
+      "source": [
+        "You can also use the `@` operator which is equivalent to numpy's `dot` operator."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vyrWA-mXSdtt"
+      },
+      "source": [
+        "print(v @ w)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zvUODeTxL9iw"
+      },
+      "source": [
+        "# Matrix / vector product; both produce the rank 1 array [29 67]\n",
+        "print(x.dot(v))\n",
+        "print(np.dot(x, v))\n",
+        "print(x @ v)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3V_3NzNEL9iy"
+      },
+      "source": [
+        "# Matrix / matrix product; both produce the rank 2 array\n",
+        "# [[19 22]\n",
+        "#  [43 50]]\n",
+        "print(x.dot(y))\n",
+        "print(np.dot(x, y))\n",
+        "print(x @ y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FbE-1If_L9i0"
+      },
+      "source": [
+        "Numpy provides many useful functions for performing computations on arrays; one of the most useful is `sum`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "DZUdZvPrL9i0"
+      },
+      "source": [
+        "x = np.array([[1,2],[3,4]])\n",
+        "\n",
+        "print(np.sum(x))  # Compute sum of all elements; prints \"10\"\n",
+        "print(np.sum(x, axis=0))  # Compute sum of each column; prints \"[4 6]\"\n",
+        "print(np.sum(x, axis=1))  # Compute sum of each row; prints \"[3 7]\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ahdVW4iUL9i3"
+      },
+      "source": [
+        "You can find the full list of mathematical functions provided by numpy in the [documentation](http://docs.scipy.org/doc/numpy/reference/routines.math.html).\n",
+        "\n",
+        "Apart from computing mathematical functions using arrays, we frequently need to reshape or otherwise manipulate data in arrays. The simplest example of this type of operation is transposing a matrix; to transpose a matrix, simply use the T attribute of an array object:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "63Yl1f3oL9i3"
+      },
+      "source": [
+        "print(x)\n",
+        "print(\"transpose\\n\", x.T)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "mkk03eNIL9i4"
+      },
+      "source": [
+        "v = np.array([[1,2,3]])\n",
+        "print(v )\n",
+        "print(\"transpose\\n\", v.T)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "REfLrUTcL9i7"
+      },
+      "source": [
+        "###Broadcasting"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EygGAMWqL9i7"
+      },
+      "source": [
+        "Broadcasting is a powerful mechanism that allows numpy to work with arrays of different shapes when performing arithmetic operations. Frequently we have a smaller array and a larger array, and we want to use the smaller array multiple times to perform some operation on the larger array.\n",
+        "\n",
+        "For example, suppose that we want to add a constant vector to each row of a matrix. We could do it like this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WEEvkV1ZL9i7"
+      },
+      "source": [
+        "# We will add the vector v to each row of the matrix x,\n",
+        "# storing the result in the matrix y\n",
+        "x = np.array([[1,2,3], [4,5,6], [7,8,9], [10, 11, 12]])\n",
+        "v = np.array([1, 0, 1])\n",
+        "y = np.empty_like(x)   # Create an empty matrix with the same shape as x\n",
+        "\n",
+        "# Add the vector v to each row of the matrix x with an explicit loop\n",
+        "for i in range(4):\n",
+        "    y[i, :] = x[i, :] + v\n",
+        "\n",
+        "print(y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2OlXXupEL9i-"
+      },
+      "source": [
+        "This works; however when the matrix `x` is very large, computing an explicit loop in Python could be slow. Note that adding the vector v to each row of the matrix `x` is equivalent to forming a matrix `vv` by stacking multiple copies of `v` vertically, then performing elementwise summation of `x` and `vv`. We could implement this approach like this:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vS7UwAQQL9i-"
+      },
+      "source": [
+        "vv = np.tile(v, (4, 1))  # Stack 4 copies of v on top of each other\n",
+        "print(vv)                # Prints \"[[1 0 1]\n",
+        "                         #          [1 0 1]\n",
+        "                         #          [1 0 1]\n",
+        "                         #          [1 0 1]]\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "N0hJphSIL9jA"
+      },
+      "source": [
+        "y = x + vv  # Add x and vv elementwise\n",
+        "print(y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zHos6RJnL9jB"
+      },
+      "source": [
+        "Numpy broadcasting allows us to perform this computation without actually creating multiple copies of v. Consider this version, using broadcasting:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "vnYFb-gYL9jC"
+      },
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "# We will add the vector v to each row of the matrix x,\n",
+        "# storing the result in the matrix y\n",
+        "x = np.array([[1,2,3], [4,5,6], [7,8,9], [10, 11, 12]])\n",
+        "v = np.array([1, 0, 1])\n",
+        "y = x + v  # Add v to each row of x using broadcasting\n",
+        "print(y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "08YyIURKL9jH"
+      },
+      "source": [
+        "The line `y = x + v` works even though `x` has shape `(4, 3)` and `v` has shape `(3,)` due to broadcasting; this line works as if v actually had shape `(4, 3)`, where each row was a copy of `v`, and the sum was performed elementwise.\n",
+        "\n",
+        "Broadcasting two arrays together follows these rules:\n",
+        "\n",
+        "1. If the arrays do not have the same rank, prepend the shape of the lower rank array with 1s until both shapes have the same length.\n",
+        "2. The two arrays are said to be compatible in a dimension if they have the same size in the dimension, or if one of the arrays has size 1 in that dimension.\n",
+        "3. The arrays can be broadcast together if they are compatible in all dimensions.\n",
+        "4. After broadcasting, each array behaves as if it had shape equal to the elementwise maximum of shapes of the two input arrays.\n",
+        "5. In any dimension where one array had size 1 and the other array had size greater than 1, the first array behaves as if it were copied along that dimension\n",
+        "\n",
+        "If this explanation does not make sense, try reading the explanation from the [documentation](http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html) or this [explanation](http://wiki.scipy.org/EricsBroadcastingDoc).\n",
+        "\n",
+        "Functions that support broadcasting are known as universal functions. You can find the list of all universal functions in the [documentation](http://docs.scipy.org/doc/numpy/reference/ufuncs.html#available-ufuncs).\n",
+        "\n",
+        "Here are some applications of broadcasting:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "EmQnwoM9L9jH"
+      },
+      "source": [
+        "# Compute outer product of vectors\n",
+        "v = np.array([1,2,3])  # v has shape (3,)\n",
+        "w = np.array([4,5])    # w has shape (2,)\n",
+        "# To compute an outer product, we first reshape v to be a column\n",
+        "# vector of shape (3, 1); we can then broadcast it against w to yield\n",
+        "# an output of shape (3, 2), which is the outer product of v and w:\n",
+        "\n",
+        "print(np.reshape(v, (3, 1)) * w)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "PgotmpcnL9jK"
+      },
+      "source": [
+        "# Add a vector to each row of a matrix\n",
+        "x = np.array([[1,2,3], [4,5,6]])\n",
+        "# x has shape (2, 3) and v has shape (3,) so they broadcast to (2, 3),\n",
+        "# giving the following matrix:\n",
+        "\n",
+        "print(x + v)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "T5hKS1QaL9jK"
+      },
+      "source": [
+        "# Add a vector to each column of a matrix\n",
+        "# x has shape (2, 3) and w has shape (2,).\n",
+        "# If we transpose x then it has shape (3, 2) and can be broadcast\n",
+        "# against w to yield a result of shape (3, 2); transposing this result\n",
+        "# yields the final result of shape (2, 3) which is the matrix x with\n",
+        "# the vector w added to each column. Gives the following matrix:\n",
+        "\n",
+        "print((x.T + w).T)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "JDUrZUl6L9jN"
+      },
+      "source": [
+        "# Another solution is to reshape w to be a row vector of shape (2, 1);\n",
+        "# we can then broadcast it directly against x to produce the same\n",
+        "# output.\n",
+        "print(x + np.reshape(w, (2, 1)))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "VzrEo4KGL9jP"
+      },
+      "source": [
+        "# Multiply a matrix by a constant:\n",
+        "# x has shape (2, 3). Numpy treats scalars as arrays of shape ();\n",
+        "# these can be broadcast together to shape (2, 3), producing the\n",
+        "# following array:\n",
+        "print(x * 2)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "89e2FXxFL9jQ"
+      },
+      "source": [
+        "Broadcasting typically makes your code more concise and faster, so you should strive to use it where possible."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "iF3ZtwVNL9jQ"
+      },
+      "source": [
+        "This brief overview has touched on many of the important things that you need to know about numpy, but is far from complete. Check out the [numpy reference](http://docs.scipy.org/doc/numpy/reference/) to find out much more about numpy."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0hgVWLaXL9jR"
+      },
+      "source": [
+        "Matplotlib is a plotting library. In this section give a brief introduction to the `matplotlib.pyplot` module, which provides a plotting system similar to that of MATLAB."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tEINf4bEL9jR"
+      },
+      "source": [
+        "##Matplotlib"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "cmh_7c6KL9jR"
+      },
+      "source": [
+        "import matplotlib.pyplot as plt"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jOsaA5hGL9jS"
+      },
+      "source": [
+        "By running this special iPython command, we will be displaying plots inline:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ijpsmwGnL9jT"
+      },
+      "source": [
+        "%matplotlib inline"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U5Z_oMoLL9jV"
+      },
+      "source": [
+        "###Plotting"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6QyFJ7dhL9jV"
+      },
+      "source": [
+        "The most important function in `matplotlib` is plot, which allows you to plot 2D data. Here is a simple example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pua52BGeL9jW"
+      },
+      "source": [
+        "# Compute the x and y coordinates for points on a sine curve\n",
+        "x = np.arange(0, 3 * np.pi, 0.1)\n",
+        "y = np.sin(x)\n",
+        "\n",
+        "# Plot the points using matplotlib\n",
+        "plt.plot(x, y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9W2VAcLiL9jX"
+      },
+      "source": [
+        "With just a little bit of extra work we can easily plot multiple lines at once, and add a title, legend, and axis labels:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "TfCQHJ5AL9jY"
+      },
+      "source": [
+        "y_sin = np.sin(x)\n",
+        "y_cos = np.cos(x)\n",
+        "\n",
+        "# Plot the points using matplotlib\n",
+        "plt.plot(x, y_sin)\n",
+        "plt.plot(x, y_cos)\n",
+        "plt.xlabel('x axis label')\n",
+        "plt.ylabel('y axis label')\n",
+        "plt.title('Sine and Cosine')\n",
+        "plt.legend(['Sine', 'Cosine'])"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "R5IeAY03L9ja"
+      },
+      "source": [
+        "###Subplots "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CfUzwJg0L9ja"
+      },
+      "source": [
+        "You can plot different things in the same figure using the subplot function. Here is an example:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dM23yGH9L9ja"
+      },
+      "source": [
+        "# Compute the x and y coordinates for points on sine and cosine curves\n",
+        "x = np.arange(0, 3 * np.pi, 0.1)\n",
+        "y_sin = np.sin(x)\n",
+        "y_cos = np.cos(x)\n",
+        "\n",
+        "# Set up a subplot grid that has height 2 and width 1,\n",
+        "# and set the first such subplot as active.\n",
+        "plt.subplot(2, 1, 1)\n",
+        "\n",
+        "# Make the first plot\n",
+        "plt.plot(x, y_sin)\n",
+        "plt.title('Sine')\n",
+        "\n",
+        "# Set the second subplot as active, and make the second plot.\n",
+        "plt.subplot(2, 1, 2)\n",
+        "plt.plot(x, y_cos)\n",
+        "plt.title('Cosine')\n",
+        "\n",
+        "# Show the figure.\n",
+        "plt.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gLtsST5SL9jc"
+      },
+      "source": [
+        "You can read much more about the `subplot` function in the [documentation](http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.subplot)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Skkig51bl5K7"
+      },
+      "source": [
+        "##Pandas"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zMV5RHx3mK_D"
+      },
+      "source": [
+        "import pandas as pd"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ZwSO-IK3mUcw"
+      },
+      "source": [
+        "data = {\n",
+        "  \"calories\": [420, 380, 390],\n",
+        "  \"duration\": [50, 40, 45]\n",
+        "}\n",
+        "\n",
+        "#load data into a DataFrame object:\n",
+        "df = pd.DataFrame(data)\n",
+        "\n",
+        "print(df) "
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hnGvDmmbmND6"
+      },
+      "source": [
+        "You have now imported pandas and can start wrangling data!"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yWYolFCXmcnQ"
+      },
+      "source": [
+        "###DataFrames"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LmpNhXz7mjDr"
+      },
+      "source": [
+        "A Pandas DataFrame is a 2 dimensional data structure, like a 2 dimensional array, or a table with rows and columns. As you can see from the result above, the DataFrame is like a table with rows and columns.\n",
+        "\n",
+        "Pandas use the loc attribute to return one or more specified row(s)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "GBHmLQH3mSTm"
+      },
+      "source": [
+        "#refer to the row index:\n",
+        "print(df.loc[0])\n",
+        "#this returns row 0"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "un5jORE2npsH"
+      },
+      "source": [
+        "#use a list of indexes:\n",
+        "print(df.loc[[0, 1]])\n",
+        "#this returns row 0 and 1"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uX45DIeln-AV"
+      },
+      "source": [
+        "Now you now how to handle DataFrames, you can start creating one with actual data! The one below is a test dataset to test the accuracy of a machine learning model to predict housing prices in California."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "gPBX-CS4oDbt"
+      },
+      "source": [
+        "df = pd.read_csv('/content/sample_data/california_housing_test.csv')\n",
+        "\n",
+        "df"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U5COoFmmorQG"
+      },
+      "source": [
+        "###Analyzing Data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "W2PzgF9Lovi4"
+      },
+      "source": [
+        "Get a quick overview by printing the first 10 rows of the DataFrame:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "AUR5Eyw4os0M"
+      },
+      "source": [
+        "df.head(10)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mW6zIDJgo1Ol"
+      },
+      "source": [
+        "Or print the last 5 rows:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "L_f-zVmdo3hQ"
+      },
+      "source": [
+        "df.tail()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "COnbFY9lo65s"
+      },
+      "source": [
+        "Would you like to get more info on the dataset? Try the following line"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "GkB3QcKIo_LY"
+      },
+      "source": [
+        "df.info()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TsLjWV9P7uS_"
+      },
+      "source": [
+        "Or if you are looking for some descriptive statistics, you can check out the following line of code:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "7MXOum0D70N0"
+      },
+      "source": [
+        "df.describe()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "stwRSFH25ggG"
+      },
+      "source": [
+        "Next we can try looking at only the house prices column. We can do this with the following line:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "J1ZzgB1j5pkv"
+      },
+      "source": [
+        "df['median_house_value']"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3uWpCxim5xZW"
+      },
+      "source": [
+        "Next, let's see if we can sort them to find out the most expensive houses of California!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "3ecM_lcl53c4"
+      },
+      "source": [
+        "df['median_house_value'].sort_values(ascending=False).head(10)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "G75f_tSR5RhG"
+      },
+      "source": [
+        "Next, let's trying something a bit more complex. Let's create a subset of the DataFrame by only selecting the top 10 most expensive houses to see their attributes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Qe9ajTkg6TOQ"
+      },
+      "source": [
+        "df_top10 = df['median_house_value'].sort_values(ascending=False).head(10)\n",
+        "new_df = df.loc[df_top10.index]"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MoudPYiX_Wrl"
+      },
+      "source": [
+        "Now trying to see if this worked by print out the new DataFrame!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WJTCcTgM_by-"
+      },
+      "source": [
+        "#print out the new DataFrame we created here\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "V3b1AnT5sB0L"
+      },
+      "source": [
+        "To find out more about the power of pandas check out the [documentation](https://pandas.pydata.org/docs/)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aBOodspLpGH9"
+      },
+      "source": [
+        "# The End\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uKqFhziQpNnv"
+      },
+      "source": [
+        "Tot volgende week voor een hands-on workshop met machine learning!"
+      ]
+    }
+  ]
+}

--- a/app/src/main/java/com/example/forage/ui/AddForageableFragment.kt
+++ b/app/src/main/java/com/example/forage/ui/AddForageableFragment.kt
@@ -50,9 +50,9 @@ class AddForageableFragment : Fragment() {
     // onDestroyView.
     private val binding get() = _binding!!
 
-    private val viewModel: ForageableViewModel by lazy {
+    private val viewModel : ForageableViewModel by activityViewModels{
         val forageableDao = (requireActivity().application as BaseApplication).forageDatabase.forageableDao
-        ForageableViewModelFactory(forageableDao).create()
+        ForageableViewModelFactory(requireActivity(),forageableDao)
     }
 
 

--- a/app/src/main/java/com/example/forage/ui/ForageableDetailFragment.kt
+++ b/app/src/main/java/com/example/forage/ui/ForageableDetailFragment.kt
@@ -40,9 +40,9 @@ class ForageableDetailFragment : Fragment() {
 
     private val navigationArgs: ForageableDetailFragmentArgs by navArgs()
 
-    private val viewModel: ForageableViewModel by lazy {
+    private val viewModel : ForageableViewModel by activityViewModels{
         val forageableDao = (requireActivity().application as BaseApplication).forageDatabase.forageableDao
-        ForageableViewModelFactory(forageableDao).create()
+        ForageableViewModelFactory(requireActivity(),forageableDao)
     }
 
     private lateinit var forageable: Forageable

--- a/app/src/main/java/com/example/forage/ui/ForageableListFragment.kt
+++ b/app/src/main/java/com/example/forage/ui/ForageableListFragment.kt
@@ -20,6 +20,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.example.forage.BaseApplication
 import com.example.forage.R
@@ -35,9 +36,9 @@ import com.example.forage.ui.viewmodel.ForageableViewModelFactory
  */
 class ForageableListFragment : Fragment() {
 
-    private val viewModel: ForageableViewModel by lazy {
+    private val viewModel : ForageableViewModel by activityViewModels{
         val forageableDao = (requireActivity().application as BaseApplication).forageDatabase.forageableDao
-        ForageableViewModelFactory(forageableDao).create()
+        ForageableViewModelFactory(requireActivity(),forageableDao)
     }
 
     private var _binding: FragmentForageableListBinding? = null

--- a/app/src/main/java/com/example/forage/ui/viewmodel/ForageableViewModel.kt
+++ b/app/src/main/java/com/example/forage/ui/viewmodel/ForageableViewModel.kt
@@ -15,8 +15,10 @@
  */
 package com.example.forage.ui.viewmodel
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.*
+import androidx.savedstate.SavedStateRegistryOwner
 import com.example.forage.BaseApplication
 import com.example.forage.data.ForageDatabase
 import com.example.forage.data.ForageableDao
@@ -30,6 +32,7 @@ import kotlinx.coroutines.launch
  */
 
 class ForageableViewModel(
+    private val state: SavedStateHandle,
     private val forageableDao: ForageableDao
 ): ViewModel() {
 
@@ -90,9 +93,13 @@ class ForageableViewModel(
 }
 
 class ForageableViewModelFactory(
-    private val forageableDao: ForageableDao
-) {
-    fun create(): ForageableViewModel {
-        return ForageableViewModel(forageableDao)
-    }
+    owner: SavedStateRegistryOwner,
+    private val forageableDao: ForageableDao,
+    defaultArgs: Bundle? = null
+) : AbstractSavedStateViewModelFactory(owner, defaultArgs){
+    override fun <T : ViewModel?> create(
+        key: String,
+        modelClass: Class<T>,
+        handle: SavedStateHandle
+    ): T = ForageableViewModel(handle, forageableDao) as T
 }


### PR DESCRIPTION
When you are calling create() directly on the viewModelFactory, you are instantiating a new viewModel on every fragment, on every visit.
This fix implements a correct custom viewModelFactory which provides the Dao (and a savedStateHandle), and uses the viewModel-lifecycle.